### PR TITLE
Add dotenv dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@supabase/supabase-js": "^2.39.7",
         "airtable": "^0.12.2",
         "docx": "^8.5.0",
+        "dotenv": "^16.5.0",
         "file-saver": "^2.0.5",
         "framer-motion": "^11.18.2",
         "jspdf": "^2.5.1",
@@ -5596,6 +5597,18 @@
       "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "docx": "^8.5.0",
     "file-saver": "^2.0.5",
     "source-map-js": "^1.2.1",
-    "airtable": "^0.12.2"
+    "airtable": "^0.12.2",
+    "dotenv": "^16.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",


### PR DESCRIPTION
## Summary
- install and include `dotenv` in package.json

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684194fdfd78832db8c3cac21748016b