### PR TITLE
Implement Airtable integration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,2 @@
+AIRTABLE_API_KEY=din_airtable_api_nyckel
+AIRTABLE_BASE_ID=din_airtable_base_id

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/src/api/airtableClient.js
+++ b/src/api/airtableClient.js
@@ -1,0 +1,12 @@
+import Airtable from 'airtable';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const { AIRTABLE_API_KEY, AIRTABLE_BASE_ID } = process.env;
+
+Airtable.configure({ apiKey: AIRTABLE_API_KEY });
+
+const base = Airtable.base(AIRTABLE_BASE_ID);
+
+export default base;

--- a/src/api/airtableService.js
+++ b/src/api/airtableService.js
@@ -1,0 +1,106 @@
+import base from './airtableClient.js';
+
+async function getAll(table) {
+  const records = await base(table).select().all();
+  return records.map(r => ({ id: r.id, ...r.fields }));
+}
+
+async function createIn(table, fieldsObject) {
+  const record = await base(table).create(fieldsObject);
+  return { id: record.id, ...record.fields };
+}
+
+async function updateIn(table, recordId, fieldsObject) {
+  const record = await base(table).update(recordId, fieldsObject);
+  return { id: record.id, ...record.fields };
+}
+
+async function deleteFrom(table, recordId) {
+  await base(table).destroy(recordId);
+  return true;
+}
+
+// Fastigheter
+export async function getAllFrom_Fastigheter() {
+  return getAll('Fastigheter');
+}
+
+export async function createIn_Fastigheter(fieldsObject) {
+  return createIn('Fastigheter', fieldsObject);
+}
+
+export async function updateIn_Fastigheter(recordId, fieldsObject) {
+  return updateIn('Fastigheter', recordId, fieldsObject);
+}
+
+export async function deleteFrom_Fastigheter(recordId) {
+  return deleteFrom('Fastigheter', recordId);
+}
+
+// Drift\u00e4renden & Best\u00e4llningar
+export async function getAllFrom_Drift\u00e4renden_&_Best\u00e4llningar() {
+  return getAll('Drift\u00e4renden & Best\u00e4llningar');
+}
+
+export async function createIn_Drift\u00e4renden_&_Best\u00e4llningar(fieldsObject) {
+  return createIn('Drift\u00e4renden & Best\u00e4llningar', fieldsObject);
+}
+
+export async function updateIn_Drift\u00e4renden_&_Best\u00e4llningar(recordId, fieldsObject) {
+  return updateIn('Drift\u00e4renden & Best\u00e4llningar', recordId, fieldsObject);
+}
+
+export async function deleteFrom_Drift\u00e4renden_&_Best\u00e4llningar(recordId) {
+  return deleteFrom('Drift\u00e4renden & Best\u00e4llningar', recordId);
+}
+
+// Komponenter
+export async function getAllFrom_Komponenter() {
+  return getAll('Komponenter');
+}
+
+export async function createIn_Komponenter(fieldsObject) {
+  return createIn('Komponenter', fieldsObject);
+}
+
+export async function updateIn_Komponenter(recordId, fieldsObject) {
+  return updateIn('Komponenter', recordId, fieldsObject);
+}
+
+export async function deleteFrom_Komponenter(recordId) {
+  return deleteFrom('Komponenter', recordId);
+}
+
+// Komponentf\u00e4lt
+export async function getAllFrom_Komponentf\u00e4lt() {
+  return getAll('Komponentf\u00e4lt');
+}
+
+export async function createIn_Komponentf\u00e4lt(fieldsObject) {
+  return createIn('Komponentf\u00e4lt', fieldsObject);
+}
+
+export async function updateIn_Komponentf\u00e4lt(recordId, fieldsObject) {
+  return updateIn('Komponentf\u00e4lt', recordId, fieldsObject);
+}
+
+export async function deleteFrom_Komponentf\u00e4lt(recordId) {
+  return deleteFrom('Komponentf\u00e4lt', recordId);
+}
+
+// Komponenttyper
+export async function getAllFrom_Komponenttyper() {
+  return getAll('Komponenttyper');
+}
+
+export async function createIn_Komponenttyper(fieldsObject) {
+  return createIn('Komponenttyper', fieldsObject);
+}
+
+export async function updateIn_Komponenttyper(recordId, fieldsObject) {
+  return updateIn('Komponenttyper', recordId, fieldsObject);
+}
+
+export async function deleteFrom_Komponenttyper(recordId) {
+  return deleteFrom('Komponenttyper', recordId);
+}

--- a/src/hooks/useDriftarenden.js
+++ b/src/hooks/useDriftarenden.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import { getAllFrom_Drift\u00e4renden_&_Best\u00e4llningar } from '../api/airtableService.js';
+
+export function useDriftarenden() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const records = await getAllFrom_Drift\u00e4renden_&_Best\u00e4llningar();
+        setData(records);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  return { data, loading, error };
+}

--- a/src/hooks/useFastigheter.js
+++ b/src/hooks/useFastigheter.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import { getAllFrom_Fastigheter } from '../api/airtableService.js';
+
+export function useFastigheter() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const records = await getAllFrom_Fastigheter();
+        setData(records);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  return { data, loading, error };
+}

--- a/src/hooks/useKomponenter.js
+++ b/src/hooks/useKomponenter.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import { getAllFrom_Komponenter } from '../api/airtableService.js';
+
+export function useKomponenter() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const records = await getAllFrom_Komponenter();
+        setData(records);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  return { data, loading, error };
+}

--- a/src/hooks/useKomponentfalt.js
+++ b/src/hooks/useKomponentfalt.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import { getAllFrom_Komponentf\u00e4lt } from '../api/airtableService.js';
+
+export function useKomponentf\u00e4lt() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const records = await getAllFrom_Komponentf\u00e4lt();
+        setData(records);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  return { data, loading, error };
+}

--- a/src/hooks/useKomponenttyper.js
+++ b/src/hooks/useKomponenttyper.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import { getAllFrom_Komponenttyper } from '../api/airtableService.js';
+
+export function useKomponenttyper() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const records = await getAllFrom_Komponenttyper();
+        setData(records);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
## Summary
- ignore the .env file and add template values
- create Airtable client and CRUD service
- add hooks to read from Airtable tables

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684197f61d58832da0d6036749341e74