### PR TITLE
Fix trailing period in Airtable base id

### DIFF
--- a/src/api/airtableClient.js
+++ b/src/api/airtableClient.js
@@ -4,9 +4,10 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const { AIRTABLE_API_KEY, AIRTABLE_BASE_ID } = process.env;
+const sanitizedBaseId = (AIRTABLE_BASE_ID || '').replace(/\.$/, '');
 
 Airtable.configure({ apiKey: AIRTABLE_API_KEY });
 
-const base = Airtable.base(AIRTABLE_BASE_ID);
+const base = Airtable.base(sanitizedBaseId);
 
 export default base;

--- a/src/utils/airtable.ts
+++ b/src/utils/airtable.ts
@@ -1,7 +1,7 @@
 import Airtable from 'airtable'
 
 const apiKey = import.meta.env.VITE_AIRTABLE_API_KEY
-const baseId = import.meta.env.VITE_AIRTABLE_BASE_ID
+const baseId = (import.meta.env.VITE_AIRTABLE_BASE_ID ?? '').replace(/\.$/, '')
 
 const base = new Airtable({ apiKey }).base(baseId)
 


### PR DESCRIPTION
## Summary
- sanitize Airtable base ID when configuring Airtable clients

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841e9290390832dbc3437c9e910f13e