### PR TITLE
Read Airtable credentials from Vite env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@supabase/supabase-js": "^2.39.7",
         "airtable": "^0.12.2",
         "docx": "^8.5.0",
-        "dotenv": "^16.5.0",
         "file-saver": "^2.0.5",
         "framer-motion": "^11.18.2",
         "jspdf": "^2.5.1",
@@ -5597,18 +5596,6 @@
       "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true
-    },
-    "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "docx": "^8.5.0",
     "file-saver": "^2.0.5",
     "source-map-js": "^1.2.1",
-    "airtable": "^0.12.2",
-    "dotenv": "^16.5.0"
+    "airtable": "^0.12.2"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",
@@ -40,8 +39,8 @@
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "10.4.20",
-    "tailwindcss": "3.4.17",
     "postcss": "8.4.49",
+    "tailwindcss": "3.4.17",
     "typescript": "5.7.3",
     "vite": "^6.0.11"
   }

--- a/src/api/airtableClient.js
+++ b/src/api/airtableClient.js
@@ -1,12 +1,9 @@
 import Airtable from 'airtable';
-import dotenv from 'dotenv';
 
-dotenv.config();
+const { VITE_AIRTABLE_API_KEY, VITE_AIRTABLE_BASE_ID } = import.meta.env;
+const sanitizedBaseId = (VITE_AIRTABLE_BASE_ID || '').replace(/\.$/, '');
 
-const { AIRTABLE_API_KEY, AIRTABLE_BASE_ID } = process.env;
-const sanitizedBaseId = (AIRTABLE_BASE_ID || '').replace(/\.$/, '');
-
-Airtable.configure({ apiKey: AIRTABLE_API_KEY });
+Airtable.configure({ apiKey: VITE_AIRTABLE_API_KEY });
 
 const base = Airtable.base(sanitizedBaseId);
 


### PR DESCRIPTION
## Summary
- load Airtable keys using `import.meta.env`
- remove `dotenv` dependency from package files

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842004feadc832db50ad4047a3d282b