### PR TITLE
Fix component pages imports

### DIFF
--- a/src/pages/component-instances.tsx
+++ b/src/pages/component-instances.tsx
@@ -23,7 +23,8 @@ import {
   ModalFooter,
   useDisclosure,
   Select,
-  SelectItem
+  SelectItem,
+  Textarea
 } from "@heroui/react";
 import { Icon } from "@iconify/react";
 // *** ÄNDRAT: Importera fetchKomponenter, fetchFastigheter, fetchKomponenttyper, saveKomponent ***

--- a/src/pages/financial.tsx
+++ b/src/pages/financial.tsx
@@ -18,6 +18,18 @@ import {
 } from "@heroui/react";
 import { Icon } from "@iconify/react";
 import ExportButton from "../components/export-button";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  Legend
+} from "recharts";
 
 // Sample data (oförändrat)
 const monthlyData = [


### PR DESCRIPTION
## Summary
- add missing Textarea import for component page
- import recharts chart components in financial page

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68446e55fcd0832db9ab37ef14a421e8